### PR TITLE
Adjust find_packages to make work in a wheel.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,5 @@
+__pycache__
+*.pyc
+dist
+build
+*.egg-info

--- a/setup.py
+++ b/setup.py
@@ -4,6 +4,6 @@ setuptools.setup(
     name='mkcodes',
     install_requires=['click'],
     extras_require={'markdown': ['markdown']},
-    packages=setuptools.find_packages(),
+    py_modules=['mkcodes'],
     entry_points={'console_scripts': ['mkcodes=mkcodes:main']}
 )


### PR DESCRIPTION
Prior to this change, `setup.py bdist_wheel` does not include
mkcodes.py, and this mechanism is used by `pip install .`

Also add gitignore to make development a little cleaner.