### PR TITLE
Ensure that mkdirs eventually stops.

### DIFF
--- a/mkcodes.py
+++ b/mkcodes.py
@@ -91,7 +91,7 @@ def get_files(inputs):
 def makedirs(directory):
     to_make = []
 
-    while True:
+    while directory:
         try:
             os.mkdir(directory)
         except FileNotFoundError:


### PR DESCRIPTION
With the default value for `--output` that doesn't have a `/` in it,
this would loop forever.  Now ensure that it only loops once per path
component.