### PR TITLE
More languages 

### DIFF
--- a/mkcodes.py
+++ b/mkcodes.py
@@ -15,10 +15,8 @@ else:
 
 # much easier to write the other names that an extension is known by
 ext_map = {
-    'cs': ['c#', 'csharp', 'c-sharp', 'cs', 'CS', 'CSHARP', 'C#'],
-    'java': ['java', 'JAVA', 'Java'],
-    'py': ['python', 'py', 'python2', 'python3', 'py2', 'py3', 'PYTHON',
-           'Python'],
+    'cs': ['c#', 'csharp', 'c-sharp'],
+    'py': ['python', 'python2', 'python3', 'py2', 'py3'],
 }
 # then invert that mapping
 language_map = {}
@@ -62,6 +60,7 @@ def github_codeblocks(filepath, safe, default_lang='py'):
                 lang_match = re.match(codeblock_open_re, line)
                 if lang_match:
                     language = lang_match.group(2)
+                    language = language.lower() if language else language
                     if not safe:
                         # we can sub a default language if not safe
                         language = language or default_lang
@@ -160,5 +159,5 @@ def main(inputs, output, github, safe, package_python, default_lang):
                 # make sure path exists, don't care if it already does
                 outputfilename.parent.mkdir(parents=True, exist_ok=True)
                 outputfilename.write_text('\n\n'.join(blocks))
-                if package_python and lang=='py':
+                if package_python and lang == 'py':
                     add_inits_along_path(outputbasedir, outputfilename.parent)

--- a/mkcodes.py
+++ b/mkcodes.py
@@ -35,6 +35,7 @@ def github_codeblocks(filepath, safe, default_lang='py'):
     codeblock_open_re = r'^```(`*)(\w+){0}$'.format('' if safe else '?')
 
     with open(filepath, 'r') as f:
+        # Initialize State
         block = []
         language = None
         in_codeblock = False
@@ -51,9 +52,9 @@ def github_codeblocks(filepath, safe, default_lang='py'):
                         ext = language_map.get(language, language)
                         codeblocks.setdefault(ext, []).append(''.join(block))
 
+                    # Reset State
                     block = []
-                    if safe:
-                        language = None
+                    language = None
                     in_codeblock = False
                 else:
                     block.append(line)

--- a/mkcodes.py
+++ b/mkcodes.py
@@ -114,10 +114,8 @@ def main(inputs, output, github, safe, package_python):
 
             outputfilename.parent.mkdir(parents=True, exist_ok=True)
             outputfilename.write_text('\n\n'.join(codeblocks))
-<<<<<<< HEAD
             if package_python:
                 add_inits_to_dir(outputbasedir)
 
-=======
->>>>>>> simplify file write and make_directories
-
+            if package_python:
+                add_inits_to_dir(outputbasedir)

--- a/mkcodes.py
+++ b/mkcodes.py
@@ -125,11 +125,10 @@ def add_inits_along_path(from_path, to_path):
     # Sanity Check: This will raise an exception if paths aren't relative.
     to_path.relative_to(from_path)
 
-    (to_path / '__init__.py').touch()
     if to_path == from_path:
         return
-    if from_path != to_path.parent:
-        add_inits_along_path(from_path, to_path.parent)
+    (to_path / '__init__.py').touch()
+    add_inits_along_path(from_path, to_path.parent)
 
 
 @click.command()

--- a/mkcodes.py
+++ b/mkcodes.py
@@ -88,7 +88,6 @@ def add_inits_to_dir(path):
             (child / '__init__.py').touch()
 
 
-
 @click.command()
 @click.argument(
     'inputs', nargs=-1, required=True, type=click.Path(exists=True))
@@ -115,7 +114,10 @@ def main(inputs, output, github, safe, package_python):
 
             outputfilename.parent.mkdir(parents=True, exist_ok=True)
             outputfilename.write_text('\n\n'.join(codeblocks))
+<<<<<<< HEAD
             if package_python:
                 add_inits_to_dir(outputbasedir)
 
+=======
+>>>>>>> simplify file write and make_directories
 

--- a/mkcodes.py
+++ b/mkcodes.py
@@ -125,10 +125,10 @@ def add_inits_along_path(from_path, to_path):
     # Sanity Check: This will raise an exception if paths aren't relative.
     to_path.relative_to(from_path)
 
-    if to_path == from_path:
-        return
-    (to_path / '__init__.py').touch()
-    add_inits_along_path(from_path, to_path.parent)
+    # Continue recursing if we haven't reached the base output directory.
+    if to_path != from_path:
+        (to_path / '__init__.py').touch()
+        add_inits_along_path(from_path, to_path.parent)
 
 
 @click.command()

--- a/mkcodes.py
+++ b/mkcodes.py
@@ -14,10 +14,12 @@ else:
     from markdown.treeprocessors import Treeprocessor
 
 # much easier to write the other names that an extension is known by
-ext_map = {'py': ['python', 'py', 'python2', 'python3', 'py2', 'py3',
-           'PYTHON', 'Python']}
-ext_map['cs'] = ['c#', 'csharp', 'c-sharp', 'cs', 'CS', 'CSHARP', 'C#']
-ext_map['java'] = ['java', 'JAVA', 'Java']
+ext_map = {
+    'cs': ['c#', 'csharp', 'c-sharp', 'cs', 'CS', 'CSHARP', 'C#'],
+    'java': ['java', 'JAVA', 'Java'],
+    'py': ['python', 'py', 'python2', 'python3', 'py2', 'py3', 'PYTHON',
+           'Python'],
+}
 # then invert that mapping
 language_map = {}
 for ext, lang_strings in ext_map.items():
@@ -45,9 +47,7 @@ def github_codeblocks(filepath, safe, default_lang='py'):
                     if language:
                         # finished a codeblock, append everything
                         ext = language_map.get(language, language)
-                        blocks = codeblocks.get(ext, [])
-                        blocks.append(''.join(block))
-                        codeblocks[ext] = blocks
+                        codeblocks.setdefault(ext, []).append(''.join(block))
 
                     block = []
                     if safe:
@@ -84,8 +84,8 @@ def markdown_codeblocks(filepath, safe, default_lang='py'):
     class DoctestCollector(Treeprocessor):
         def run(self, root):
             nonlocal codeblocks
-            codeblocks[default_lang] =\
-                (block.text for block in root.iterfind('./pre/code'))
+            codeblocks[default_lang] = (
+                block.text for block in root.iterfind('./pre/code'))
 
     class DoctestExtension(Extension):
         def extendMarkdown(self, md, md_globals):

--- a/mkcodes.py
+++ b/mkcodes.py
@@ -139,8 +139,8 @@ def add_inits_along_path(from_path, to_path):
               help='Allow code blocks without language hints.')
 @click.option('--package-python', default=True,
               help='Add __init__.py files to python dirs for test discovery')
-@click.option('--default_lang', default='py',
-              help='Assumed language for code blocks without language hits.')
+@click.option('--default-lang', default='py',
+              help='Assumed language for code blocks without language hints.')
 def main(inputs, output, github, safe, package_python, default_lang):
     collect_codeblocks = github_codeblocks if github else markdown_codeblocks
     outputbasedir = Path(output).parent

--- a/mkcodes.py
+++ b/mkcodes.py
@@ -121,12 +121,15 @@ def add_inits_along_path(from_path, to_path):
     """
     to_path = to_path.expanduser().resolve()
     from_path = from_path.expanduser().resolve()
+
+    # Sanity Check: This will raise an exception if paths aren't relative.
+    to_path.relative_to(from_path)
+
     (to_path / '__init__.py').touch()
     if to_path == from_path:
         return
-    if to_path.relative_to(from_path):
-        if from_path != to_path.parent:
-            add_inits_along_path(from_path, to_path.parent)
+    if from_path != to_path.parent:
+        add_inits_along_path(from_path, to_path.parent)
 
 
 @click.command()

--- a/mkcodes.py
+++ b/mkcodes.py
@@ -42,13 +42,22 @@ def github_codeblocks(filepath, safe):
                     python = False
     return codeblocks
 """
+# much easier to write the other names that an extension is known by
+ext_map = {'py': ['python', 'py', 'python2', 'python3', 'py2', 'py3', 'PYTHON', 'Python']}
+ext_map['cs'] = ['c#','csharp', 'c-sharp', 'cs', 'CS', 'CSHARP', 'C#']
+ext_map['java'] = ['java', 'JAVA', 'Java']
+# then invert that mapping
+language_map = {}
+for ext, lang_strings in ext_map.items():
+    for lang_string in lang_strings:
+        language_map[lang_string] = ext
 
-def github_codeblocks(filepath, safe):
+
+def github_codeblocks(filepath, safe, default_lang='py'):
     codeblocks = []
     codeblock_re = r'^```.*'
     codeblock_open_re = r'^```(`*)(py|python){0}$'.format('' if safe else '?')
 
-    # import pudb; pu.db
     with open(filepath, 'r') as f:
         block = []
         language = None
@@ -76,14 +85,19 @@ def github_codeblocks(filepath, safe):
                 in_codeblock = True
                 # does it have a language?
                 lang_match = re.match(codeblock_open_re, line)
-                if not lang_match:
-                    language = None
-                else:
+                if lang_match:
                     language = lang_match.group(2)
-
+                    if not safe:
+                        # we can sub a default language if not safe
+                        language = language or default_lang
+                else:
+                    if safe:
+                        language = None
+                    else:
+                        language = default_lang
     return codeblocks
 
-def github_markdown_codeblocks(filepath, safe):
+def github_markdown_codeblocks(filepath, safe, default_lang='py'):
     import markdown
     codeblocks =[]
     if safe:
@@ -92,7 +106,6 @@ def github_markdown_codeblocks(filepath, safe):
     class DoctestCollector(Treeprocessor):
         def run(self, root):
             nonlocal codeblocks
-            import pudb; pu.db
             codeblocks = (block.text for block in root.iterfind('./pre/code'))
 
     class DoctestExtension(Extension):

--- a/mkcodes.py
+++ b/mkcodes.py
@@ -2,6 +2,7 @@ import os
 from pathlib import Path
 import re
 import warnings
+
 import click
 
 try:

--- a/mkcodes.py
+++ b/mkcodes.py
@@ -13,12 +13,16 @@ else:
     from markdown.extensions import Extension
     from markdown.treeprocessors import Treeprocessor
 
-# much easier to write the other names that an extension is known by
+# There does not seem to be any specification for which info strings are
+# accepted, but python-markdown passes it directly to pygments, so their
+# mapping can be used as a guide:
+# https://github.com/pygments/pygments/blob/master/pygments/lexers/_mapping.py
 ext_map = {
     'cs': ['c#', 'csharp', 'c-sharp'],
     'py': ['python', 'python2', 'python3', 'py2', 'py3'],
 }
-# then invert that mapping
+# It's more straightforward to express the mappings by extension, but we
+# actually need an inverted mapping.
 language_map = {}
 for ext, lang_strings in ext_map.items():
     for lang_string in lang_strings:

--- a/mkcodes.py
+++ b/mkcodes.py
@@ -54,7 +54,7 @@ for ext, lang_strings in ext_map.items():
 
 
 def github_codeblocks(filepath, safe, default_lang='py'):
-    codeblocks = []
+    codeblocks = {}
     codeblock_re = r'^```.*'
     codeblock_open_re = r'^```(`*)(py|python){0}$'.format('' if safe else '?')
 
@@ -72,7 +72,11 @@ def github_codeblocks(filepath, safe, default_lang='py'):
                     # we are closing a codeblock
                     if language:
                         # finished a codeblock, append everything
-                        codeblocks.append(''.join(block))
+                        # codeblocks.append(''.join(block))
+                        # import pudb; pu.db
+                        blocks = codeblocks.get(language, [])
+                        blocks.append(''.join(block))
+                        codeblocks[language] = blocks
 
                     block = []
                     if safe:
@@ -99,14 +103,14 @@ def github_codeblocks(filepath, safe, default_lang='py'):
 
 def github_markdown_codeblocks(filepath, safe, default_lang='py'):
     import markdown
-    codeblocks =[]
+    codeblocks = {}
     if safe:
         warnings.warn("'safe' option not available in 'github-markdown' mode.")
 
     class DoctestCollector(Treeprocessor):
         def run(self, root):
             nonlocal codeblocks
-            codeblocks = (block.text for block in root.iterfind('./pre/code'))
+            codeblocks[default_lang] = (block.text for block in root.iterfind('./pre/code'))
 
     class DoctestExtension(Extension):
         def extendMarkdown(self, md, md_globals):
@@ -120,10 +124,10 @@ def github_markdown_codeblocks(filepath, safe, default_lang='py'):
 
 
 
-def markdown_codeblocks(filepath, safe):
+def markdown_codeblocks(filepath, safe, default_lang='py'):
     import markdown
 
-    codeblocks = []
+    codeblocks = {}
 
     if safe:
         warnings.warn("'safe' option not available in 'markdown' mode.")
@@ -131,7 +135,7 @@ def markdown_codeblocks(filepath, safe):
     class DoctestCollector(Treeprocessor):
         def run(self, root):
             nonlocal codeblocks
-            codeblocks = (block.text for block in root.iterfind('./pre/code'))
+            codeblocks[default_lang] = (block.text for block in root.iterfind('./pre/code'))
 
     class DoctestExtension(Extension):
         def extendMarkdown(self, md, md_globals):
@@ -156,43 +160,50 @@ def get_files(inputs):
         elif path.suffix in markdown_extensions:
             yield path, path.parent
 
-def add_inits_to_dir(path):
+def add_inits_along_path(from_path, to_path):
     """Recursively add __init__.py files to a directory
     This compensates for https://bugs.python.org/issue23882 and https://bugs.python.org/issue35617
     """
-    for child in path.rglob('*'):
-        if child.is_dir():
-            (child / '__init__.py').touch()
+    to_path = to_path.expanduser().resolve()
+    from_path = from_path.expanduser().resolve()
+    if to_path.relative_to_path(from_path):
+        (to_path / '__init__.py').to_pathuch()
+        if from_path.resolve() != to_path.parent.resolve():
+            add_inits_along_path(from_path, to_path.parent()
 
 
 @click.command()
 @click.argument(
     'inputs', nargs=-1, required=True, type=click.Path(exists=True))
-@click.option('--output', default='{name}.py')
+@click.option('--output', default='{name}.{ext}')
 @click.option('--github/--markdown', default=bool(not markdown_enabled),
               help='Github-flavored fence blocks or pure markdown.')
 @click.option('--safe/--unsafe', default=True,
               help='Allow code blocks without language hints.')
 @click.option('--package-python', default=True,
               help='Add __init__.py files to python output to aid in test discovery')
-def main(inputs, output, github, safe, package_python):
+@click.option('--default_lang', default='py',
+              help='Assumed language for code blocks without language hits.')
+def main(inputs, output, github, safe, package_python, default_lang):
     collect_codeblocks = github_codeblocks if github else markdown_codeblocks
     outputbasedir = Path(output).parent
     outputbasename = Path(output).name
 
     for filepath, input_path in get_files(inputs):
-        codeblocks = collect_codeblocks(filepath, safe)
+        codeblocks = collect_codeblocks(filepath, safe, default_lang)
 
         if codeblocks:
             fp = Path(filepath)
             filedir = fp.parent.relative_to(input_path)
             filename = fp.stem
-            outputfilename = outputbasedir / filedir / outputbasename.format(name=filename)
 
-            outputfilename.parent.mkdir(parents=True, exist_ok=True)
-            outputfilename.write_text('\n\n'.join(codeblocks))
-            if package_python:
-                add_inits_to_dir(outputbasedir)
+            # stitch together the OUTPUT base directory with the input directories
+            # add the file format at the end.
+            for lang, blocks in codeblocks.items():
+                outputfilename = outputbasedir / filedir / outputbasename.format(name=filename, ext=lang)
 
-            if package_python:
-                add_inits_to_dir(outputbasedir)
+                # make sure path exists, don't care if it already does
+                outputfilename.parent.mkdir(parents=True, exist_ok=True)
+                outputfilename.write_text('\n\n'.join(blocks))
+                if package_python and lang=='py':
+                    add_inits_along_path(outputbasedir, outputfilename.parent)

--- a/mkcodes.py
+++ b/mkcodes.py
@@ -43,8 +43,6 @@ def github_codeblocks(filepath, safe, default_lang='py'):
                     # we are closing a codeblock
                     if language:
                         # finished a codeblock, append everything
-                        # codeblocks.append(''.join(block))
-                        # import pudb; pu.db
                         ext = language_map.get(language, language)
                         blocks = codeblocks.get(ext, [])
                         blocks.append(''.join(block))
@@ -111,16 +109,20 @@ def get_files(inputs):
         elif path.suffix in markdown_extensions:
             yield path, path.parent
 
+
 def add_inits_along_path(from_path, to_path):
     """Recursively add __init__.py files to a directory
-    This compensates for https://bugs.python.org/issue23882 and https://bugs.python.org/issue35617
+    This compensates for https://bugs.python.org/issue23882
+    and https://bugs.python.org/issue35617
     """
     to_path = to_path.expanduser().resolve()
     from_path = from_path.expanduser().resolve()
-    if to_path.relative_to_path(from_path):
-        (to_path / '__init__.py').to_pathuch()
-        if from_path.resolve() != to_path.parent.resolve():
-            add_inits_along_path(from_path, to_path.parent()
+    (to_path / '__init__.py').touch()
+    if to_path == from_path:
+        return
+    if to_path.relative_to(from_path):
+        if from_path != to_path.parent:
+            add_inits_along_path(from_path, to_path.parent)
 
 
 @click.command()
@@ -132,7 +134,7 @@ def add_inits_along_path(from_path, to_path):
 @click.option('--safe/--unsafe', default=True,
               help='Allow code blocks without language hints.')
 @click.option('--package-python', default=True,
-              help='Add __init__.py files to python output to aid in test discovery')
+              help='Add __init__.py files to python dirs for test discovery')
 @click.option('--default_lang', default='py',
               help='Assumed language for code blocks without language hits.')
 def main(inputs, output, github, safe, package_python, default_lang):

--- a/mkcodes.py
+++ b/mkcodes.py
@@ -51,6 +51,10 @@ def github_codeblocks(filepath, safe, default_lang='py'):
                         # finished a codeblock, append everything
                         ext = language_map.get(language, language)
                         codeblocks.setdefault(ext, []).append(''.join(block))
+                    else:
+                        warnings.warn('No language hint found in safe mode. ' +
+                                      'Skipping block beginning with: ' +
+                                      block[0])
 
                     # Reset State
                     block = []

--- a/mkcodes.py
+++ b/mkcodes.py
@@ -64,11 +64,6 @@ def github_codeblocks(filepath, safe, default_lang='py'):
                     if not safe:
                         # we can sub a default language if not safe
                         language = language or default_lang
-                else:
-                    if safe:
-                        language = None
-                    else:
-                        language = default_lang
     return codeblocks
 
 

--- a/tests/data/nest/more/why.md
+++ b/tests/data/nest/more/why.md
@@ -1,6 +1,6 @@
 # why?
 
-We want to make sure that in more complext documentation structures, which may have multiple sub directories, we are still formatting name and paths correctly.
+We want to make sure that in more complex documentation structures, which may have multiple sub directories, we are still formatting name and paths correctly.
 
 ```py
 import unittest

--- a/tests/langdata/csharp.md
+++ b/tests/langdata/csharp.md
@@ -11,7 +11,7 @@ public void Sum(int a, int b)
 
 And we know that it is testable.
 
-```cs
+```csharp
 [Testclass]
 public class UnitTest1
 {

--- a/tests/langdata/csharp.md
+++ b/tests/langdata/csharp.md
@@ -1,0 +1,34 @@
+# dotNet is still a thing
+
+What if you could provide a code sample here?
+
+```cs
+public void Sum(int a, int b)
+{
+      return a + b;
+}
+```
+
+And we know that it is testable.
+
+```cs
+[Testclass]
+public class UnitTest1
+{
+    [TestMethod]
+    public void TestMethod1()
+    {
+        //Arrange
+        ApplicationToTest.Calc ClassCalc = new ApplicationToTest.Calc();
+        int expectedResult = 5;
+
+        //Act
+        int result = ClassCalc.Sum(2,3);
+
+        //Assert
+        Assert.AreEqual(expectedResult, result);
+    }
+}
+```
+
+Actually checking and running these tests, that's a different matter.

--- a/tests/langdata/java.md
+++ b/tests/langdata/java.md
@@ -1,0 +1,32 @@
+# Java documentation is important
+
+That's a language still. Here's a java codeblock:
+
+```java
+public class MyUnit {
+    public String concatenate(String one, String two){
+      return one + two;
+    }
+}
+```
+
+And since we have that class, let's test it
+
+```java
+import org.junit.Test;
+import static org.junit.Assert.*;
+
+public class MyUnitTest {
+
+    @Test
+    public void testConcatenate() {
+        MyUnit myUnit = new MyUnit();
+
+        String result = myUnit.concatenate("one", "two");
+
+        assertEquals("onetwo", result);
+
+    }
+}
+
+```

--- a/tests/langdata/multilang.md
+++ b/tests/langdata/multilang.md
@@ -1,0 +1,28 @@
+# Comparing and contrasting
+
+For some ideas about an api, we might give getting started code in a simple getting started page.
+
+In a pinch, let's hello that world.
+
+```py
+print("hello, world")
+```
+
+But maybe we want this to be enterprise grade?
+
+```java
+class HelloWorld {
+  public static void main(String[] args) {
+    System.out.println("Hello, World!"); 
+  }
+}
+```
+
+New orders from the CTO: let's use Azure cloud.
+```cs
+class HelloWorld {
+  static void Main() {
+    System.Console.WriteLine("Hello World");
+  }
+}
+```

--- a/tests/langdata/multilang.md
+++ b/tests/langdata/multilang.md
@@ -26,3 +26,9 @@ class HelloWorld {
   }
 }
 ```
+
+We want to have a react vue jquery frontend. Assume that the code sample below has a testable extension as the language
+
+```js
+consol.log('Hello, world");
+```

--- a/tests/langdata/multilang.md
+++ b/tests/langdata/multilang.md
@@ -30,5 +30,5 @@ class HelloWorld {
 We want to have a react vue jquery frontend. Assume that the code sample below has a testable extension as the language
 
 ```js
-consol.log('Hello, world");
+console.log('Hello, world");
 ```

--- a/tests/langdata/no_py_tree/clean.md
+++ b/tests/langdata/no_py_tree/clean.md
@@ -1,0 +1,16 @@
+# Cleanliness
+
+If there are no python files in a directory, we don't need to add an __init__.py file to that directory. Sure, they don't hurt, but having them where they aren't needed isn't very tidy and might be confusing.
+
+Speaking of confusing, lets test javascript
+```js
+function assert(condition, message) {
+    if (!condition) {
+        message = message || "Assertion failed";
+        throw new Error(message);
+    }
+}
+
+assert([]+[]=="", "very sensible, adding arrays is a string")
+assert({}+[]==0, "of course adding a dict to an array is 0")
+```

--- a/tests/langdata/pytree/buried.md
+++ b/tests/langdata/pytree/buried.md
@@ -1,0 +1,12 @@
+# Test discovery
+
+For test discovery to work for unittest, python files generated from this document must have an `__init__.py` file added to the directory - otherwise they won't be considered testable packages.
+
+```python
+import unittest
+
+class TestDiscovery(unittest.TestCase):
+  def test_discovery(self):
+    self.assertTrue(True)
+
+```

--- a/tests/test.py
+++ b/tests/test.py
@@ -157,6 +157,9 @@ class TestInputs(TestBase):
         self.assertTrue(self._output_path_exists('pytree/test_buried.py'))
         self.assertTrue(self._output_path_exists('pytree/__init__.py'))
 
+        # __init__.py should not be created in the base output directory.
+        self.assertFalse(self._output_path_exists('__init__.py'))
+
     @unittest.skip
     def test_glob(self):
         raise NotImplementedError

--- a/tests/test.py
+++ b/tests/test.py
@@ -96,6 +96,7 @@ class TestInputs(TestBase):
         self.assertTrue(self._output_path_exists('nest/deep.py'))
         self.assertFalse(self._output_path_exists('not_markdown.py'))
         self.assertTrue(self._output_path_exists('nest/more/why.py'))
+        self.assertFalse(self._output_path_exists('not_markdown.py'))
 
     def test_multiple(self):
         self.call(

--- a/tests/test.py
+++ b/tests/test.py
@@ -143,10 +143,11 @@ class TestInputs(TestBase):
 
     def test_other_languages(self):
         subprocess.call([
-            'mkcodes', '--output', 'tests/output/test_{name}.py',
-            'tests/langdata'])
+            'mkcodes', '--output', 'tests/output/test_{name}.{ext}',
+            '--github', 'tests/langdata'])
         self.assertTrue(self._output_path_exists('test_java.java'))
         self.assertTrue(self._output_path_exists('test_csharp.cs'))
+        self.assertFalse(self._output_path_exists('test_csharp.csharp'))
         self.assertTrue(self._output_path_exists('test_multilang.cs'))
         self.assertTrue(self._output_path_exists('test_multilang.java'))
         self.assertTrue(self._output_path_exists('test_multilang.py'))

--- a/tests/test.py
+++ b/tests/test.py
@@ -141,6 +141,16 @@ class TestInputs(TestBase):
         self.assertIn('Ran 2 tests', proc.stderr)
         self.assertIn('OK', proc.stderr)
 
+    def test_other_languages(self):
+        subprocess.call([
+            'mkcodes', '--output', 'tests/output/test_{name}.py', '--github',
+            'tests/langdata'])
+        self.assertTrue(self._output_path_exists('test_java.java'))
+        self.assertTrue(self._output_path_exists('test_csharp.cs'))
+        self.assertTrue(self._output_path_exists('test_multilang.cs'))
+        self.assertTrue(self._output_path_exists('test_multilang.java'))
+        self.assertTrue(self._output_path_exists('test_multilang.py'))
+
     @unittest.skip
     def test_glob(self):
         raise NotImplementedError

--- a/tests/test.py
+++ b/tests/test.py
@@ -152,6 +152,10 @@ class TestInputs(TestBase):
         self.assertTrue(self._output_path_exists('test_multilang.java'))
         self.assertTrue(self._output_path_exists('test_multilang.py'))
         self.assertTrue(self._output_path_exists('test_multilang.js'))
+        self.assertTrue(self._output_path_exists('no_py_tree/test_clean.js'))
+        self.assertFalse(self._output_path_exists('no_py_tree/__init__.py'))
+        self.assertTrue(self._output_path_exists('pytree/test_buried.py'))
+        self.assertTrue(self._output_path_exists('pytree/__init__.py'))
 
     @unittest.skip
     def test_glob(self):

--- a/tests/test.py
+++ b/tests/test.py
@@ -151,6 +151,7 @@ class TestInputs(TestBase):
         self.assertTrue(self._output_path_exists('test_multilang.cs'))
         self.assertTrue(self._output_path_exists('test_multilang.java'))
         self.assertTrue(self._output_path_exists('test_multilang.py'))
+        self.assertTrue(self._output_path_exists('test_multilang.js'))
 
     @unittest.skip
     def test_glob(self):

--- a/tests/test.py
+++ b/tests/test.py
@@ -96,7 +96,6 @@ class TestInputs(TestBase):
         self.assertTrue(self._output_path_exists('nest/deep.py'))
         self.assertFalse(self._output_path_exists('not_markdown.py'))
         self.assertTrue(self._output_path_exists('nest/more/why.py'))
-        self.assertFalse(self._output_path_exists('not_markdown.py'))
 
     def test_multiple(self):
         self.call(

--- a/tests/test.py
+++ b/tests/test.py
@@ -142,9 +142,9 @@ class TestInputs(TestBase):
         self.assertIn('OK', proc.stderr)
 
     def test_other_languages(self):
-        subprocess.call([
-            'mkcodes', '--output', 'tests/output/test_{name}.{ext}',
-            '--github', 'tests/langdata'])
+        self.call(
+            '--output', 'tests/output/test_{name}.{ext}',
+            '--github', 'tests/langdata')
         self.assertTrue(self._output_path_exists('test_java.java'))
         self.assertTrue(self._output_path_exists('test_csharp.cs'))
         self.assertFalse(self._output_path_exists('test_csharp.csharp'))

--- a/tests/test.py
+++ b/tests/test.py
@@ -143,7 +143,7 @@ class TestInputs(TestBase):
 
     def test_other_languages(self):
         subprocess.call([
-            'mkcodes', '--output', 'tests/output/test_{name}.py', '--github',
+            'mkcodes', '--output', 'tests/output/test_{name}.py',
             'tests/langdata'])
         self.assertTrue(self._output_path_exists('test_java.java'))
         self.assertTrue(self._output_path_exists('test_csharp.cs'))


### PR DESCRIPTION
Ensure that we output each language in a file per markdown document. 

If there are multiple language blocks in one document, each goes to the right file.

If the language is python, output __init__.py package indicators along the output tree to a file.

Allow multiple language descriptions for markdown blocks to go to the same file extension ("csharp", "c#" and "cs" all output ".cs" files)